### PR TITLE
Agent cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Key                       | Description
 SQLALCHEMY_DATABASE_URI   | The database URI that should be used for the connection. default='sqlite://'
 AGENT_RETURN_TIME         | Default polling interval for agents, defined in seconds. default=60
 AGENT_ACTIVE_THRESHOLD    | Timeout to wait before considering an agent as lost, defined in seconds. default=300
+AGENT_DROP_THRESHOLD      | Timeout to wait before deleting a lost agent, defined in seconds. default=3600
 AUTO_CREATE               | Automatically create database tables before the first request. default=True
+AUTO_CLEANUP              | Run cleanup routines every time an agent requests for tasks. default=True
 LOG_FILE                  | Output log to a file instead of stderr. default=None
 LOG_LEVEL                 | Output log level. default=logging.DEBUG. With environment variables use either integer values or one of the [standard logging level names](https://docs.python.org/3/library/logging.html#levels).
 LOG_FORMAT                | Output log format. default=`'%(asctime)s - %(name)s - %(levelname)s - %(message).120s'`

--- a/slamon_afm/app.py
+++ b/slamon_afm/app.py
@@ -1,12 +1,11 @@
 import logging
-from datetime import datetime, timedelta
 
 import os
 from flask import Flask
 
 from sqlalchemy import event
 
-from slamon_afm.models import db, Agent, Task
+from slamon_afm.models import db
 from slamon_afm.routes import agent_routes, bpms_routes, status_routes, dashboard_routes
 
 

--- a/slamon_afm/app.py
+++ b/slamon_afm/app.py
@@ -5,6 +5,7 @@ import os
 from flask import Flask
 
 from slamon_afm.models import db
+from sqlalchemy import event
 from slamon_afm.routes import agent_routes, bpms_routes, status_routes, dashboard_routes
 
 
@@ -79,5 +80,13 @@ def create_app(config=None, config_file=None):
 
     # register app for Flask-SQLAlchemy DB
     db.init_app(app)
+
+    # register event listener to enable foreign_keys for SQLite databases
+    def on_connect(conn, record):
+        if db.engine.name == 'sqlite':
+            conn.execute('pragma foreign_keys=ON')
+
+    with app.app_context():
+        event.listen(db.engine, 'connect', on_connect)
 
     return app

--- a/slamon_afm/app.py
+++ b/slamon_afm/app.py
@@ -1,11 +1,12 @@
 import logging
+from datetime import datetime, timedelta
 
 import os
-
 from flask import Flask
 
-from slamon_afm.models import db
 from sqlalchemy import event
+
+from slamon_afm.models import db, Agent, Task
 from slamon_afm.routes import agent_routes, bpms_routes, status_routes, dashboard_routes
 
 
@@ -38,7 +39,9 @@ class DefaultConfig(object):
     SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI', 'sqlite://')
     AGENT_RETURN_TIME = int(os.getenv('AGENT_RETURN_TIME', 60))
     AGENT_ACTIVE_THRESHOLD = int(os.getenv('AGENT_ACTIVE_THRESHOLD', 300))
+    AGENT_DROP_THRESHOLD = int(os.getenv('AGENT_DROP_THRESHOLD', 3600))
     AUTO_CREATE = _bool_from_str(os.getenv('AUTO_CREATE', 'True'))
+    AUTO_CLEANUP = _bool_from_str(os.getenv('AUTO_CLEANUP', 'True'))
     LOG_FILE = os.getenv('LOG_FILE', None)
     LOG_LEVEL = _log_level_from_str(os.getenv('LOG_LEVEL', 'INFO'))
     LOG_FORMAT = os.getenv('LOG_FORMAT', '%(asctime)s - %(name)s - %(levelname)s - %(message).120s')

--- a/slamon_afm/routes/agent_routes.py
+++ b/slamon_afm/routes/agent_routes.py
@@ -130,7 +130,7 @@ def request_tasks():
         try:
             current_app.logger.debug("Cleaning inactive agents...")
             Agent.drop_inactive(datetime.utcnow() - timedelta(0, current_app.config['AGENT_DROP_THRESHOLD']))
-            Task.unassign_inactive(datetime.utcnow() - timedelta(0, current_app.config['AGENT_ACTIVE_THRESHOLD']))
+            Task.update_inactive(datetime.utcnow() - timedelta(0, current_app.config['AGENT_ACTIVE_THRESHOLD']))
             db.session.commit()
         except SQLAlchemyError as e:
             current_app.logger.error("Failed cleaning up inactive agents: {0}".format(e))

--- a/slamon_afm/routes/bpms_routes.py
+++ b/slamon_afm/routes/bpms_routes.py
@@ -105,24 +105,25 @@ def get_task(task_uuid):
     try:
         query = db.session.query(Task)
         task = query.filter(Task.uuid == str(task_uuid)).one()
+
+        task_desc = {
+            'task_id': task.uuid,
+            'test_id': task.test_id,
+            'task_type': task.type,
+            'task_version': task.version
+        }
+
+        if task.data is not None:
+            task_desc['task_data'] = json.loads(task.data)
+
+        if task.failed:
+            task_desc['task_failed'] = str(task.failed)
+            task_desc['task_error'] = str(task.error)
+        elif task.completed:
+            task_desc['task_completed'] = str(task.completed)
+            task_desc['task_result'] = json.loads(task.result_data)
+
+        return jsonify(task_desc)
+
     except NoResultFound:
         abort(404)
-
-    task_desc = {
-        'task_id': task.uuid,
-        'test_id': task.test_id,
-        'task_type': task.type,
-        'task_version': task.version
-    }
-
-    if task.data is not None:
-        task_desc['task_data'] = json.loads(task.data)
-
-    if task.failed:
-        task_desc['task_failed'] = str(task.failed)
-        task_desc['task_error'] = str(task.error)
-    elif task.completed:
-        task_desc['task_completed'] = str(task.completed)
-        task_desc['task_result'] = json.loads(task.result_data)
-
-    return jsonify(task_desc)

--- a/slamon_afm/tests/afm_test.py
+++ b/slamon_afm/tests/afm_test.py
@@ -25,6 +25,7 @@ class AFMTest(TestCase):
         self.test_app = TestApp(self.app)
 
     def tearDown(self):
+        db.session.rollback()
         db.drop_all()
         self.app_context.pop()
 

--- a/slamon_afm/tests/agent_routes_tests.py
+++ b/slamon_afm/tests/agent_routes_tests.py
@@ -133,11 +133,11 @@ class TestPolling(AFMTest):
         agent = db.session.query(Agent).filter(Agent.uuid == 'de305d54-75b4-431b-adb2-eb6b9e546013').one()
         self.assertEqual(len(agent.capabilities), 3)
 
-        self.assertEqual(db.session.query(AgentCapability).filter(AgentCapability.agent_uuid == agent.uuid). \
+        self.assertEqual(db.session.query(AgentCapability).filter(AgentCapability.agent_uuid == agent.uuid).
                          filter(AgentCapability.type == 'task-type-1').one().version, 2)
-        self.assertEqual(db.session.query(AgentCapability).filter(AgentCapability.agent_uuid == agent.uuid). \
+        self.assertEqual(db.session.query(AgentCapability).filter(AgentCapability.agent_uuid == agent.uuid).
                          filter(AgentCapability.type == 'task-type-3').one().version, 3)
-        self.assertEqual(db.session.query(AgentCapability).filter(AgentCapability.agent_uuid == agent.uuid). \
+        self.assertEqual(db.session.query(AgentCapability).filter(AgentCapability.agent_uuid == agent.uuid).
                          filter(AgentCapability.type == 'task-type-4').one().version, 4)
 
     def test_poll_tasks_invalid_data(self):

--- a/slamon_afm/tests/models_tests.py
+++ b/slamon_afm/tests/models_tests.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+
+from slamon_afm.models import db, Task, Agent, AgentCapability
+from slamon_afm.tests.afm_test import AFMTest
+
+
+class TaskUnassignTests(AFMTest):
+    """
+    These tests are not actually testing any code but continuing
+    the tradition of using DB withing unittests by checking if the
+    SQLAlchemy declarations work as intended.
+    """
+
+    def setUp(self):
+        super(TaskUnassignTests, self).setUp()
+
+        self.agent = Agent(
+            uuid='de305d54-75b4-431b-adb2-eb6b9e546013',
+            name='test agent',
+            last_seen=datetime.utcnow()
+        )
+        db.session.add(self.agent)
+
+        self.task = Task(
+            uuid='de305d54-75b4-431b-adb2-eb6b9e546013',
+            test_id='de305d54-75b4-431b-adb2-eb6b9e546013',
+            type='task-type-1',
+            version=1,
+            data="{}",
+            assigned_agent=self.agent
+        )
+        db.session.add(self.task)
+
+        db.session.flush()
+
+    def testUnassignInactive(self):
+        Task.unassign_inactive(datetime.utcnow())
+        db.session.flush()
+        db.session.refresh(self.agent)
+        db.session.refresh(self.task)
+
+        self.assertEqual(len(self.agent.tasks), 0)
+        self.assertIsNone(self.task.assigned_agent_uuid)
+
+    def testDropAgents(self):
+        Agent.drop_inactive(datetime.utcnow())
+        db.session.flush()
+        db.session.refresh(self.task)
+
+        self.assertEqual(db.session.query(Agent).count(), 0)
+        self.assertIsNone(self.task.assigned_agent_uuid)
+
+    def testDropAgentsWithCapabilities(self):
+        self.agent.capabilities.append(AgentCapability(type='task-type-test', version=1))
+        db.session.flush()
+
+        Agent.drop_inactive(datetime.utcnow())
+
+        db.session.flush()
+        db.session.refresh(self.task)
+
+        self.assertEqual(db.session.query(Agent).count(), 0)
+        self.assertIsNone(self.task.assigned_agent_uuid)
+
+
+class TaskClaimingTests(AFMTest):
+    def setUp(self):
+        super(TaskClaimingTests, self).setUp()
+        self.agent = Agent(
+            uuid='de305d54-75b4-431b-adb2-eb6b9e546013',
+            name='test agent',
+            last_seen=datetime.utcnow(),
+            capabilities=[AgentCapability(type='task-type-1', version=1)]
+        )
+        db.session.add(self.agent)
+        db.session.flush()
+
+    def testClaimUnassignedTask(self):
+        task = Task(
+            uuid='de305d54-75b4-431b-adb2-eb6b9e546013',
+            test_id='de305d54-75b4-431b-adb2-eb6b9e546013',
+            type='task-type-1',
+            version=1,
+            data="{}"
+        )
+        db.session.add(task)
+        db.session.flush()
+
+        claimed = list(Task.claim_tasks(self.agent, 1))
+        self.assertEqual(len(claimed), 1)
+
+    def testDontClaimCompleteTasks(self):
+        task = Task(
+            uuid='de305d54-75b4-431b-adb2-eb6b9e546013',
+            test_id='de305d54-75b4-431b-adb2-eb6b9e546013',
+            type='task-type-1',
+            version=1,
+            data="{}",
+            completed=datetime.now(),
+            result_data='{}'
+        )
+        db.session.add(task)
+        db.session.flush()
+
+        claimed = list(Task.claim_tasks(self.agent, 1))
+        self.assertEqual(len(claimed), 0)
+
+    def testDontClaimErrorTasks(self):
+        task = Task(
+            uuid='de305d54-75b4-431b-adb2-eb6b9e546013',
+            test_id='de305d54-75b4-431b-adb2-eb6b9e546013',
+            type='task-type-1',
+            version=1,
+            data="{}",
+            failed=datetime.now(),
+            error='some error'
+        )
+        db.session.add(task)
+        db.session.flush()
+
+        claimed = list(Task.claim_tasks(self.agent, 1))
+        self.assertEqual(len(claimed), 0)

--- a/slamon_afm/tests/models_tests.py
+++ b/slamon_afm/tests/models_tests.py
@@ -32,6 +32,8 @@ class TaskUnassignTests(AFMTest):
         db.session.add(self.task)
 
         db.session.flush()
+        self.assertEqual(len(self.agent.tasks), 1)
+        self.assertIsNotNone(self.task.assigned_agent_uuid)
 
     def testUnassignInactive(self):
         Task.unassign_inactive(datetime.utcnow())


### PR DESCRIPTION
- Routines to deassign tasks claimed by inactive agents and to delete lost agents
- Updated ForeignKey onupdate and ondelete constraints to enable agent deletion
- a hack to automatically enable foreign key constraints in SQLite
