### PR TITLE
Correct ordering for tasks query when selecting tasks to be claimed.

### DIFF
--- a/slamon_afm/models.py
+++ b/slamon_afm/models.py
@@ -172,7 +172,8 @@ class Task(db.Model):
         query = db.session.query(AgentCapability, Task). \
             filter(and_(Task.assigned_agent_uuid.is_(None), Task.completed.is_(None), Task.error.is_(None))). \
             filter(AgentCapability.agent_uuid == agent.uuid). \
-            filter(and_(AgentCapability.type == Task.type, AgentCapability.version == Task.version))
+            filter(and_(AgentCapability.type == Task.type, AgentCapability.version == Task.version)). \
+            order_by(Task.created)
 
         # Assign available tasks to the agent and mark them as being in process
         for _, task in query[0:max_tasks]:


### PR DESCRIPTION
Currently there's no ordering for tasks claimed by agent. This leads to unfair processing of tasks when tasks are being queued.

Tasks needs to be claimed/processed in FIFO order for consistent measuring of test flows.
