### PR TITLE
Using gunicorn to run AFM in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.4
 # non-root account for the service
 RUN groupadd -r slamon && useradd -r -g slamon slamon 
 
+RUN pip3 install --no-cache-dir psycopg2 gunicorn aiohttp
+
 # Add AFM sources for installation
 ADD "setup.py" "/tmp/slamon_afm/"
 ADD "slamon_afm" "/tmp/slamon_afm/slamon_afm"
@@ -14,7 +16,8 @@ RUN pip install --no-cache-dir /tmp/slamon_afm
 RUN rm -rf /tmp/slamon_afm
 
 # default to in memory sqlite db
-ENV AFM_DB_URI sqlite://
+ENV AFM_DB_URI sqlite:////tmp/slamon.db
+ENV AFM_WORKERS=4
 
 # Expose the AFM HTTP port
 EXPOSE 8080
@@ -22,5 +25,4 @@ EXPOSE 8080
 # Change to a non-root user
 USER slamon
 
-CMD ["/bin/sh", "-c", "slamon-afm --database-uri=${AFM_DB_URI} run 0.0.0.0 8080"]
-
+CMD ["/bin/sh", "-c", "gunicorn -w ${AFM_WORKERS} -b 0.0.0.0:8080 --env SQLALCHEMY_DATABASE_URI=${AFM_DB_URI} slamon_afm.wsgi:app"]

--- a/slamon_afm/wsgi.py
+++ b/slamon_afm/wsgi.py
@@ -1,0 +1,3 @@
+from slamon_afm.app import create_app
+
+app = create_app()


### PR DESCRIPTION
Updated docker image to use gunicorn instead of built-in server to make it production ready.
- Dockerfile DB defaults to in file sqlite to be shared among multiple processes
- added slamon_afm.wsgi module to simpilify running afm as generic wsgi app.
